### PR TITLE
Prevent recursive notifications

### DIFF
--- a/src/java/org/jivesoftware/openfire/plugin/ContentFilterPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/ContentFilterPlugin.java
@@ -566,7 +566,13 @@ public class ContentFilterPlugin implements Plugin, PacketInterceptor {
         return patternsEnabled
                 && !processed
                 && read
-                && (packet instanceof Message || (filterStatusEnabled && packet instanceof Presence));
+                && (packet instanceof Message || (filterStatusEnabled && packet instanceof Presence))
+                && isNotServerGeneratedPacket(packet);
+    }
+    
+    private boolean isNotServerGeneratedPacket(Packet packet) {
+        return packet.getFrom().getNode() != null
+            && packet.getFrom().getNode().length() > 0;
     }
 
     private void sendViolationNotification(Packet originalPacket) {


### PR DESCRIPTION
Fixes #1

Doesn't attempt to filter any packets that have originated from the server (have no Node in the JID)

No tests, as the code is on the Plugin class, and the effort to set this up for unit testing would be larger that the fix. Sorry :(